### PR TITLE
update expected trace for when UNIVERSAL::import exists

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -4,12 +4,22 @@ use File::Spec::Functions;
 my $tdir = catdir qw(t lib);
 my $tfile = catfile qw(t scr.pl);
 my $first_ret = $] < 5.016000 ? 'undef' : '';
-my $initial = $] < 5.028000 ? '' : <<EOF;
+my $initial = $] < 5.028000 ? ''
+  : $] < 5.039001 ? <<EOF
 main::($tfile:0)(Devel::Tra)
 return()
 EOF
-my $first_block = $] < 5.028000 ? '' : <<EOF;
+  : <<EOF;
+UNIVERSAL::import(Devel::Tra)
+return()
+EOF
+my $first_block = $] < 5.028000 ? ''
+  : $] < 5.039001 ? <<EOF
   main::($tfile:1)(Thing)
+  return($first_ret)
+EOF
+  : <<EOF;
+  UNIVERSAL::import(Thing)
   return($first_ret)
 EOF
 


### PR DESCRIPTION
New versions of perl have a real UNIVERSAL::import method, which will appear in the trace logs this module generates. Update the expected logs in the tests to account for this.